### PR TITLE
fix: Add addCodeInReport to constructor arguments in initializeAllureReport()

### DIFF
--- a/src/allure-base-environment.ts
+++ b/src/allure-base-environment.ts
@@ -199,6 +199,7 @@ function extendAllureBaseEnvironment<TBase extends typeof JestEnvironment>(Base:
 				environmentInfo: config.projectConfig.testEnvironmentOptions?.environmentInfo as Record<string, any>,
 				categories: config.projectConfig.testEnvironmentOptions?.categories as Array<Record<string, any>>,
 				labels: [] as Labels[],
+				addCodeInReport: config.projectConfig.testEnvironmentOptions?.addCodeInReport as boolean ?? true
 			});
 		}
 


### PR DESCRIPTION
I noticed that the `addCodeInReport` property from `testEnvironmentOptions` in `jest.config.ts` is not passed to the `AllureReporter` upon initialization.

Turns out it was missing in the method 😉 

I added it and if it is not present it will pass the default value `true`. It should not break existing installations that way.